### PR TITLE
Tweak serve message to have full url

### DIFF
--- a/volofile
+++ b/volofile
@@ -275,7 +275,7 @@ module.exports = {
                               ":res[content-length] - :response-time ms");
         middleware.unshift(connect.logger("OpenWebApp"));
 
-        console.log("starting web server on port " + port);
+        console.log("starting web server at http://localhost:" + port);
         connect.apply(null, middleware).listen(port);
 
     }


### PR DESCRIPTION
My terminal emulator lets me click on urls and pop them up in my
browser. This makes it easier to do that.

r?
