### PR TITLE
Make volo serve to react on the environment PORT as well.

### DIFF
--- a/volofile
+++ b/volofile
@@ -178,7 +178,7 @@ module.exports = {
 
         var lessMiddleware = require('less-middleware');
 
-        var port = port || 8008;
+        var port = port || process.env.PORT || 8008;
         var base = path.join(process.cwd(), namedArgs.base || 'www');
         var middleware = [
             lessMiddleware({ src: base }),


### PR DESCRIPTION
Many nodeJS applications consider environmental variable PORT when
starting a webserver.

Signed-off-by: Matěj Cepl mcepl@redhat.com
